### PR TITLE
docs(CLAUDE.md): document the agent-router nested install required on fresh checkouts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,10 @@ AI Studio codebase guidance for Claude Code. Optimized for token efficiency and 
 # install fails typecheck (20 errors) and 1 test:ci suite, because
 # infra/lambdas/agent-router/ resolves its AWS SDK deps from its OWN package.json)
 bun install
-(cd infra/lambdas/agent-router && bun install)
+(cd infra/lambdas/agent-router && bun install --frozen-lockfile)
+# ^ keep --frozen-lockfile: no lockfile is committed there, so it resolves fresh
+#   WITHOUT writing one — a plain install writes a local bun.lock that silently
+#   pins your installs while CI floats
 
 # Local Development (Issue #607)
 bun run db:up              # Start local PostgreSQL (Docker)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,12 @@ AI Studio codebase guidance for Claude Code. Optimized for token efficiency and 
 ## 🚀 Quick Reference
 
 ```bash
+# Fresh checkout — install BOTH manifests (CI does the same; a root-only
+# install fails typecheck (20 errors) and 1 test:ci suite, because
+# infra/lambdas/agent-router/ resolves its AWS SDK deps from its OWN package.json)
+bun install
+(cd infra/lambdas/agent-router && bun install)
+
 # Local Development (Issue #607)
 bun run db:up              # Start local PostgreSQL (Docker)
 bun run dev:local          # Run Next.js with local database


### PR DESCRIPTION
## Summary

Docs-only. A fresh checkout that runs only the root `bun install` fails two local gates, and the failure masquerades as a missing dependency:

- `bun run typecheck` → 20 errors, all in `infra/lambdas/agent-router/index.ts`: TS2307 for `@aws-sdk/client-ecs` and `@googleapis/chat`, 17 TS2345 `@smithy` type-duplication errors (root `lib-dynamodb@3.1095` / `client-bedrock-agent-runtime@3.1092` nest `@smithy/types@4.16.1` against the 3.982-generation clients on hoisted `4.12.0`), plus one downstream TS7006.
- `bun run test:ci` → `tests/unit/agent-workspace-identity.test.ts` fails with `Cannot find module '@aws-sdk/client-ecs'` (the only jest suite importing the router module unmocked).

The actual gap is a missing **install step**, not a missing dependency: the agent-router Lambda is a self-contained package with its own `package.json`, and CI already runs `bun install --frozen-lockfile` inside `infra/lambdas/agent-router/` ("Install agent-router dependencies" in `ci.yml`) — which is why dev CI is green while root-only local installs are red. With the nested `node_modules`, `index.ts` resolves one mutually consistent SDK/@smithy family and all 20 errors plus the jest failure disappear.

This PR adds the two-command install sequence to the CLAUDE.md Quick Reference.

## Deliberately NOT changed

- **No `@aws-sdk/client-ecs` in root `package.json`** — duplicative of the Lambda's own manifest (drift risk) and it would fix only 1 of the 20 typecheck errors.
- **No committed `bun.lock` in the lambda dir** — the two npm-based build paths (the Docker bundling fallback in `agent-platform-stack.ts` and the job-runner `Dockerfile`) cannot read `bun.lock`, and the floating install always resolves a single coherent SDK generation — the exact property whose absence causes the root-side @smithy skew.
- **Deploy bundle unaffected and verified**: no esbuild is involved; the CDK asset bundling, `infra/build-lambdas.sh`, and the job-runner image all install from the Lambda's own `package.json`, which already declares `@aws-sdk/client-ecs`.

## Verification

- Reproduced both failures on a root-only install in a clean worktree.
- After `(cd infra/lambdas/agent-router && bun install)`: `bun run typecheck` exit 0; `bun run test:ci` 572 passed / 1 skipped / 0 failed.
- Pre-push authenticated E2E gate: 318 passed, 41 skipped, 1 flaky (passed on retry), 9.9m.
