### PR TITLE
fix(google-content-sync): harden against the poison-page class, make the snapshot obligation durable, type-check the lambda

### DIFF
--- a/infra/lambdas/google-content-sync/changes.ts
+++ b/infra/lambdas/google-content-sync/changes.ts
@@ -20,6 +20,7 @@ export const DRIVE_SCOPED_CHANGE_TYPE = "drive";
 export interface DriveChangeIdentity {
   changeType?: string | undefined;
   fileId?: string | undefined;
+  removed?: boolean | undefined;
 }
 
 /**
@@ -32,4 +33,25 @@ export function isFileScopedDriveChange<T extends DriveChangeIdentity>(
 ): change is T & { fileId: string } {
   if (change.changeType === DRIVE_SCOPED_CHANGE_TYPE) return false;
   return typeof change.fileId === "string" && change.fileId.length > 0;
+}
+
+/**
+ * True when a non-file-scoped entry reports that the Shared Drive itself went
+ * away — deleted, or this account lost access to it.
+ *
+ * These entries must NOT be skipped like the other drive-scoped noise. Sources
+ * already imported from that drive are now unreachable, and a connector
+ * reading the global changes feed gets no other signal: its subsequent
+ * `listChanges` and watch calls keep succeeding, so the stale content would
+ * stay active indefinitely. The caller answers this by requesting a selection
+ * snapshot, which retires whatever is no longer reachable.
+ *
+ * Deliberately not keyed on `changeType === "drive"`: the legacy "teamDrive"
+ * value and any future scope Google introduces must take this path too. What
+ * identifies the case is "removed, and not about a specific file" — which is
+ * exactly the state the caller has already established.
+ */
+export function isDriveRemovalChange(change: DriveChangeIdentity): boolean {
+  if (isFileScopedDriveChange(change)) return false;
+  return change.removed === true;
 }

--- a/infra/lambdas/google-content-sync/changes.ts
+++ b/infra/lambdas/google-content-sync/changes.ts
@@ -1,0 +1,35 @@
+/**
+ * Classification helpers for entries returned by the Google Drive Changes
+ * feed (`GET /drive/v3/changes`).
+ *
+ * The feed is not exclusively file-scoped. Google emits `changeType: "drive"`
+ * entries for Shared Drive-level events — rename, membership change,
+ * restriction change — and those entries carry NO `fileId`. There is no file
+ * to import, resolve, or mark missing for them.
+ *
+ * Every downstream step of the reconcile loop is keyed on a file id, so a
+ * `fileId`-less entry must be skipped before that work begins. `changeType` is
+ * matched as a plain string rather than an enum so a future value Google adds
+ * cannot turn the queue into poison messages again.
+ */
+
+/** Shared Drive-scoped change entries never carry a `fileId`. */
+export const DRIVE_SCOPED_CHANGE_TYPE = "drive";
+
+/** The minimum shape needed to decide whether a change entry is actionable. */
+export interface DriveChangeIdentity {
+  changeType?: string | undefined;
+  fileId?: string | undefined;
+}
+
+/**
+ * True when the entry names a specific Drive file, i.e. it is safe to hand to
+ * the file-scoped import/removal path. Drive-scoped entries and entries with a
+ * missing or empty `fileId` return false and must be skipped.
+ */
+export function isFileScopedDriveChange<T extends DriveChangeIdentity>(
+  change: T,
+): change is T & { fileId: string } {
+  if (change.changeType === DRIVE_SCOPED_CHANGE_TYPE) return false;
+  return typeof change.fileId === "string" && change.fileId.length > 0;
+}

--- a/infra/lambdas/google-content-sync/index.ts
+++ b/infra/lambdas/google-content-sync/index.ts
@@ -866,7 +866,25 @@ async function resolveShortcut(
 ): Promise<GoogleDriveFile> {
   if (file.mimeType !== GOOGLE_SHORTCUT_MIME_TYPE) return file;
   const targetId = file.shortcutDetails?.targetId;
-  if (!targetId) throw new Error(`Drive shortcut ${file.id} has no target`);
+  if (!targetId) {
+    // Typed, not a bare `Error`. `targetId` is optional in the schema (a
+    // shortcut whose target was deleted is a real Drive state, and Drive does
+    // not retroactively clean up `shortcutDetails`), so this branch is
+    // reachable on a well-formed page. A plain `Error` falls through every
+    // classification branch: `add()` rethrows it and aborts the entire
+    // selection snapshot, and `recordDriveChangeFailure` rethrows it before
+    // `reconcileChangePages` persists the page cursor — the poison-page
+    // failure this Lambda exists to prevent, relocated from Zod validation to
+    // shortcut resolution. Reusing the unreadable-record type makes both call
+    // sites treat it the way they already treat a record they cannot read:
+    // skip/fail this one entry and keep moving.
+    throw new GoogleDriveUnreadableFileError(file.id, [
+      {
+        path: "shortcutDetails.targetId",
+        message: "Drive shortcut has no target",
+      },
+    ]);
+  }
   return client.getFile(targetId);
 }
 

--- a/infra/lambdas/google-content-sync/index.ts
+++ b/infra/lambdas/google-content-sync/index.ts
@@ -1541,7 +1541,10 @@ async function setSelectionSnapshotPending(
             ? sql`${repositoryConnectors.metadata} || ${JSON.stringify({
                 [SELECTION_SNAPSHOT_PENDING_KEY]: new Date().toISOString(),
               })}::jsonb`
-            : sql`${repositoryConnectors.metadata} - ${SELECTION_SNAPSHOT_PENDING_KEY}`,
+            : // The ::text cast pins the `jsonb - text` overload explicitly;
+              // `jsonb -` is also defined for integer and text[], and the key
+              // arrives as an untyped bind parameter.
+              sql`${repositoryConnectors.metadata} - ${SELECTION_SNAPSHOT_PENDING_KEY}::text`,
           updatedAt: new Date(),
         })
         .where(

--- a/infra/lambdas/google-content-sync/index.ts
+++ b/infra/lambdas/google-content-sync/index.ts
@@ -66,6 +66,7 @@ import {
   GoogleDriveApiError,
   GoogleDriveClient,
   GoogleDriveDownloadPendingError,
+  GoogleDriveUnreadableFileError,
   type GoogleDriveChange,
   type GoogleDriveFile,
   type GoogleDriveSkippedEntry,
@@ -991,8 +992,34 @@ async function enumerateInitialFiles(
       entries: skipped,
     });
   };
+  const recordUnreadable = (
+    operation: string,
+    scopeId: string,
+    error: GoogleDriveUnreadableFileError,
+  ) => {
+    // Same disposition as a dropped list entry: the record says nothing about
+    // the file's existence, so it is skipped and counted, which marks the
+    // enumeration incomplete and suppresses markUnseenSourcesMissing.
+    skippedEntryCount += 1;
+    log.error("Google Drive returned an unreadable file record", {
+      connectorId: context.connector.id,
+      operation,
+      scopeId,
+      fileId: error.fileId,
+      issues: error.issues,
+    });
+  };
   const add = async (candidate: GoogleDriveFile, selectedVia: string) => {
-    const file = await resolveShortcut(client, candidate);
+    let file: GoogleDriveFile;
+    try {
+      file = await resolveShortcut(client, candidate);
+    } catch (error) {
+      if (error instanceof GoogleDriveUnreadableFileError) {
+        recordUnreadable("resolveShortcut", candidate.id, error);
+        return;
+      }
+      throw error;
+    }
     if (file.trashed || file.mimeType === GOOGLE_FOLDER_MIME_TYPE) return;
     const existing = discovered.get(file.id);
     if (existing) {
@@ -1025,6 +1052,13 @@ async function enumerateInitialFiles(
         recordSkipped,
       );
     } catch (error) {
+      if (error instanceof GoogleDriveUnreadableFileError) {
+        // An unreadable selection root cannot be enumerated, which says
+        // nothing about its files' existence — unlike the 403/404 branch
+        // below, where the selection itself is gone.
+        recordUnreadable("enumerateSelection", selection.externalId, error);
+        continue;
+      }
       if (
         selection.selectionKind !== "drive" &&
         isGoogleDriveMissingError(error)
@@ -1353,14 +1387,15 @@ async function reconcileInitial(
     context.connector.sharedDriveId,
   );
   const complete = await reconcileSelectionSnapshot(context, client, counters);
-  // A full rebuild discharges any outstanding obligation. Cleared
-  // unconditionally rather than gated on the connector row loaded at the start
-  // of the run: this path is also reached after a 410 cursor expiry, by which
-  // point the in-memory copy can be stale. Removing an absent jsonb key is a
-  // no-op, and an initial rebuild is rare.
-  if (complete) {
-    await setSelectionSnapshotPending(context, false);
-  }
+  // A complete rebuild discharges any outstanding obligation; an incomplete
+  // one records the obligation durably, so the next run repeats the snapshot
+  // instead of leaving the files behind a dropped entry unrecovered until
+  // each happens to change again. Written unconditionally rather than gated
+  // on the connector row loaded at the start of the run: this path is also
+  // reached after a 410 cursor expiry, by which point the in-memory copy can
+  // be stale. Removing an absent jsonb key is a no-op, and an initial rebuild
+  // is rare.
+  await setSelectionSnapshotPending(context, !complete);
   return startPageToken;
 }
 
@@ -1413,8 +1448,11 @@ async function retryDeferredDownloads(
 /**
  * Records the outcome of a failed file-scoped change. Connector lifecycle
  * errors are fatal to the whole run and are rethrown; a Drive 403/404 means the
- * file was deleted or access was lost, which is the markSourceMissing path.
- * Anything else is rethrown so the caller can fail the record.
+ * file was deleted or access was lost, which is the markSourceMissing path; an
+ * unreadable record (from `getFile` on the file itself, its shortcut target,
+ * or a parent during the selection walk) fails the one record so the page's
+ * cursor still advances. Anything else is rethrown so the caller can fail the
+ * record.
  */
 async function recordDriveChangeFailure(
   context: ConnectorContext,
@@ -1428,6 +1466,14 @@ async function recordDriveChangeFailure(
     error instanceof ConnectorSelectionChangedError
   ) {
     throw error;
+  }
+  if (error instanceof GoogleDriveUnreadableFileError) {
+    // The file very likely still exists — its record just could not be read.
+    // Never markSourceMissing here, and never rethrow: a deterministic parse
+    // failure that escaped this function would replay the page until the DLQ.
+    counters.failed += 1;
+    await recordSourceFailure(context, fileId, error);
+    return;
   }
   if (!isGoogleDriveMissingError(error)) throw error;
   if (await markSourceMissing(context, fileId)) {

--- a/infra/lambdas/google-content-sync/index.ts
+++ b/infra/lambdas/google-content-sync/index.ts
@@ -1353,8 +1353,12 @@ async function reconcileInitial(
     context.connector.sharedDriveId,
   );
   const complete = await reconcileSelectionSnapshot(context, client, counters);
-  // A full rebuild discharges any obligation an earlier run left behind.
-  if (complete && isSelectionSnapshotPending(context.connector.metadata)) {
+  // A full rebuild discharges any outstanding obligation. Cleared
+  // unconditionally rather than gated on the connector row loaded at the start
+  // of the run: this path is also reached after a 410 cursor expiry, by which
+  // point the in-memory copy can be stale. Removing an absent jsonb key is a
+  // no-op, and an initial rebuild is rare.
+  if (complete) {
     await setSelectionSnapshotPending(context, false);
   }
   return startPageToken;

--- a/infra/lambdas/google-content-sync/index.ts
+++ b/infra/lambdas/google-content-sync/index.ts
@@ -76,7 +76,7 @@ import {
 } from "../../../lib/repositories/google-drive/formats";
 import { refreshGoogleAccessToken } from "../../../lib/repositories/google-drive/oauth";
 import { getGoogleContentWifAccessToken } from "../../../lib/repositories/google-drive/wif";
-import { isFileScopedDriveChange } from "./changes";
+import { isDriveRemovalChange, isFileScopedDriveChange } from "./changes";
 import {
   assertGoogleSourceMetadataSize,
   assertGoogleSourceResponseSize,
@@ -1367,14 +1367,27 @@ async function processGoogleDriveChange(
   counters: SyncCounters,
 ): Promise<boolean> {
   // Shared Drive-scoped entries (rename, membership, restriction changes) have
-  // no fileId. Nothing below can act on them, and they must not stall the
-  // cursor: skip without side effects so the loop keeps advancing.
+  // no fileId, so nothing on the file path below can act on them.
   if (!isFileScopedDriveChange(change)) {
-    log.info("Skipped non-file Google Drive change entry", {
-      connectorId: context.connector.id,
-      changeType: change.changeType ?? null,
-    });
-    return false;
+    // A removal, though, is not noise: the Shared Drive was deleted or this
+    // account lost access, so sources imported from it are now unreachable.
+    // Requesting a selection snapshot lets markUnseenSourcesMissing retire
+    // them; a hard access loss still surfaces through the existing 403/404
+    // path. Anything else is metadata noise and is skipped without side
+    // effects so the cursor keeps advancing.
+    const driveRemoved = isDriveRemovalChange(change);
+    log.info(
+      driveRemoved
+        ? "Shared Drive removed from the change feed"
+        : "Skipped non-file Google Drive change entry",
+      {
+        connectorId: context.connector.id,
+        changeType: change.changeType ?? null,
+        driveId: change.driveId ?? null,
+        time: change.time ?? null,
+      },
+    );
+    return driveRemoved;
   }
   if (change.removed || !change.file || change.file.trashed) {
     if (await markSourceMissing(context, change.fileId)) {

--- a/infra/lambdas/google-content-sync/index.ts
+++ b/infra/lambdas/google-content-sync/index.ts
@@ -66,7 +66,9 @@ import {
   GoogleDriveApiError,
   GoogleDriveClient,
   GoogleDriveDownloadPendingError,
+  type GoogleDriveChange,
   type GoogleDriveFile,
+  type GoogleDriveSkippedEntry,
 } from "../../../lib/repositories/google-drive/drive-client";
 import {
   exportedGoogleDriveFileName,
@@ -77,6 +79,13 @@ import {
 import { refreshGoogleAccessToken } from "../../../lib/repositories/google-drive/oauth";
 import { getGoogleContentWifAccessToken } from "../../../lib/repositories/google-drive/wif";
 import { isDriveRemovalChange, isFileScopedDriveChange } from "./changes";
+import {
+  isSelectionSnapshotPending,
+  reconcileChangePages,
+  resumePendingSelectionSnapshot,
+  SELECTION_SNAPSHOT_PENDING_KEY,
+  shouldRetireUnseenSources,
+} from "./reconcile";
 import {
   assertGoogleSourceMetadataSize,
   assertGoogleSourceResponseSize,
@@ -865,16 +874,29 @@ type AddDiscoveredFile = (
   selectedVia: string,
 ) => Promise<void>;
 
+/** Reports entries Google returned that failed per-entry validation. */
+type RecordSkippedEntries = (
+  operation: string,
+  scopeId: string,
+  skipped: GoogleDriveSkippedEntry[],
+) => void;
+
 async function enumerateSharedDriveSelection(
   client: GoogleDriveClient,
   selection: RepositoryConnectorSelectionRow,
   add: AddDiscoveredFile,
+  recordSkipped: RecordSkippedEntries,
 ): Promise<void> {
   let pageToken: string | null = null;
   do {
     const page = await client.listSharedDriveFiles(
       selection.externalId,
       pageToken,
+    );
+    recordSkipped(
+      "listSharedDriveFiles",
+      selection.externalId,
+      page.skippedEntries,
     );
     for (const file of page.values) {
       await add(file, selection.externalId);
@@ -903,6 +925,7 @@ async function enumerateFileSelection(
   selection: RepositoryConnectorSelectionRow,
   budget: GoogleDriveSnapshotBudget,
   add: AddDiscoveredFile,
+  recordSkipped: RecordSkippedEntries,
 ): Promise<void> {
   const selected = await client.getFile(selection.externalId);
   if (
@@ -923,6 +946,7 @@ async function enumerateFileSelection(
     let pageToken: string | null = null;
     do {
       const page = await client.listChildren(folderId, pageToken);
+      recordSkipped("listChildren", folderId, page.skippedEntries);
       await collectFolderChildren(
         page.values,
         selection.externalId,
@@ -940,6 +964,7 @@ async function enumerateInitialFiles(
 ): Promise<{
   files: Array<{ file: GoogleDriveFile; selectedVia: string[] }>;
   inaccessibleSelectionCount: number;
+  skippedEntryCount: number;
 }> {
   const discovered = new Map<
     string,
@@ -947,6 +972,25 @@ async function enumerateInitialFiles(
   >();
   const budget = new GoogleDriveSnapshotBudget();
   let inaccessibleSelectionCount = 0;
+  let skippedEntryCount = 0;
+  const recordSkipped: RecordSkippedEntries = (
+    operation,
+    scopeId,
+    skipped,
+  ) => {
+    if (skipped.length === 0) return;
+    skippedEntryCount += skipped.length;
+    log.error("Google Drive returned unparseable list entries", {
+      connectorId: context.connector.id,
+      operation,
+      scopeId,
+      skippedCount: skipped.length,
+      // The entries are dropped, never reinterpreted as removals. The
+      // enumeration is therefore incomplete, which suppresses
+      // markUnseenSourcesMissing for this snapshot.
+      entries: skipped,
+    });
+  };
   const add = async (candidate: GoogleDriveFile, selectedVia: string) => {
     const file = await resolveShortcut(client, candidate);
     if (file.trashed || file.mimeType === GOOGLE_FOLDER_MIME_TYPE) return;
@@ -965,10 +1009,21 @@ async function enumerateInitialFiles(
   for (const selection of context.selections) {
     try {
       if (selection.selectionKind === "drive") {
-        await enumerateSharedDriveSelection(client, selection, add);
+        await enumerateSharedDriveSelection(
+          client,
+          selection,
+          add,
+          recordSkipped,
+        );
         continue;
       }
-      await enumerateFileSelection(client, selection, budget, add);
+      await enumerateFileSelection(
+        client,
+        selection,
+        budget,
+        add,
+        recordSkipped,
+      );
     } catch (error) {
       if (
         selection.selectionKind !== "drive" &&
@@ -992,6 +1047,7 @@ async function enumerateInitialFiles(
       selectedVia: [...selectedVia],
     })),
     inaccessibleSelectionCount,
+    skippedEntryCount,
   };
 }
 
@@ -1254,21 +1310,38 @@ async function importFileIsolated(
   }
 }
 
+/**
+ * Re-enumerate every selection. Resolves false when the enumeration was
+ * incomplete — the caller must not treat a snapshot obligation as discharged.
+ */
 async function reconcileSelectionSnapshot(
   context: ConnectorContext,
   client: GoogleDriveClient,
   counters: SyncCounters,
-): Promise<void> {
+): Promise<boolean> {
   const snapshot = await enumerateInitialFiles(context, client);
   counters.discovered += snapshot.files.length;
   counters.failed += snapshot.inaccessibleSelectionCount;
   for (const { file, selectedVia } of snapshot.files) {
     await importFileIsolated(context, client, file, selectedVia, counters);
   }
+  if (!shouldRetireUnseenSources(snapshot)) {
+    counters.failed += snapshot.skippedEntryCount;
+    log.error(
+      "Skipped the unseen-source sweep after an incomplete Google Drive enumeration",
+      {
+        connectorId: context.connector.id,
+        skippedEntryCount: snapshot.skippedEntryCount,
+        discovered: snapshot.files.length,
+      },
+    );
+    return false;
+  }
   counters.missing += await markUnseenSourcesMissing(
     context,
     snapshot.files.map(({ file }) => file.id),
   );
+  return true;
 }
 
 async function reconcileInitial(
@@ -1279,7 +1352,11 @@ async function reconcileInitial(
   const startPageToken = await client.getStartPageToken(
     context.connector.sharedDriveId,
   );
-  await reconcileSelectionSnapshot(context, client, counters);
+  const complete = await reconcileSelectionSnapshot(context, client, counters);
+  // A full rebuild discharges any obligation an earlier run left behind.
+  if (complete && isSelectionSnapshotPending(context.connector.metadata)) {
+    await setSelectionSnapshotPending(context, false);
+  }
   return startPageToken;
 }
 
@@ -1328,10 +1405,6 @@ async function retryDeferredDownloads(
     }
   }
 }
-
-type GoogleDriveChange = Awaited<
-  ReturnType<GoogleDriveClient["listChanges"]>
->["values"][number];
 
 /**
  * Records the outcome of a failed file-scoped change. Connector lifecycle
@@ -1447,48 +1520,87 @@ async function persistSyncCursor(
   }
 }
 
+/**
+ * Write (or clear) the durable "a selection snapshot is owed" flag on the
+ * connector.
+ *
+ * The write is a jsonb merge rather than a read-modify-write of the loaded
+ * row: the webhook path also writes connector metadata, and replaying a stale
+ * in-memory copy would clobber it.
+ */
+async function setSelectionSnapshotPending(
+  context: ConnectorContext,
+  pending: boolean,
+): Promise<void> {
+  const persisted = await executeQuery(
+    (db) =>
+      db
+        .update(repositoryConnectors)
+        .set({
+          metadata: pending
+            ? sql`${repositoryConnectors.metadata} || ${JSON.stringify({
+                [SELECTION_SNAPSHOT_PENDING_KEY]: new Date().toISOString(),
+              })}::jsonb`
+            : sql`${repositoryConnectors.metadata} - ${SELECTION_SNAPSHOT_PENDING_KEY}`,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(repositoryConnectors.id, context.connector.id),
+            eq(
+              repositoryConnectors.selectionRevision,
+              context.connector.selectionRevision,
+            ),
+            ne(repositoryConnectors.status, "revoked"),
+          ),
+        )
+        .returning({ id: repositoryConnectors.id }),
+    pending
+      ? "googleContent.markSnapshotPending"
+      : "googleContent.clearSnapshotPending",
+  );
+  if (persisted.length === 0) {
+    throw new ConnectorSelectionChangedError();
+  }
+}
+
 async function reconcileChanges(
   context: ConnectorContext,
   client: GoogleDriveClient,
   initialCursor: string,
   counters: SyncCounters,
 ): Promise<string> {
-  let cursor = initialCursor;
-  let requiresSelectionSnapshot = false;
-  for (;;) {
-    const page = await client.listChanges(
-      cursor,
-      context.connector.sharedDriveId,
-    );
-    for (const change of page.values) {
-      counters.discovered += 1;
-      requiresSelectionSnapshot =
-        (await processGoogleDriveChange(
-          context,
-          client,
-          change,
-          counters,
-        )) || requiresSelectionSnapshot;
-    }
-    cursor = page.nextPageToken ?? page.newStartPageToken ?? cursor;
-    if (!requiresSelectionSnapshot) {
-      await persistSyncCursor(
-        context,
+  return reconcileChangePages<GoogleDriveChange>(initialCursor, {
+    listChanges: async (cursor) => {
+      const page = await client.listChanges(
         cursor,
-        "googleContent.persistCursor",
+        context.connector.sharedDriveId,
       );
-    }
-    if (!page.nextPageToken) break;
-  }
-  if (requiresSelectionSnapshot) {
-    await reconcileSelectionSnapshot(context, client, counters);
-    await persistSyncCursor(
-      context,
-      cursor,
-      "googleContent.persistSnapshotCursor",
-    );
-  }
-  return cursor;
+      if (page.skippedEntries.length > 0) {
+        // Dropped, never reinterpreted: a change entry that fails validation
+        // says nothing about whether its file still exists, so no source is
+        // marked missing here. The cost is a missed update until that file
+        // changes again — visible in this line.
+        log.error("Skipped unparseable Google Drive change entries", {
+          connectorId: context.connector.id,
+          skippedCount: page.skippedEntries.length,
+          entries: page.skippedEntries,
+        });
+        counters.failed += page.skippedEntries.length;
+      }
+      return page;
+    },
+    processChange: async (change) => {
+      counters.discovered += 1;
+      return processGoogleDriveChange(context, client, change, counters);
+    },
+    persistCursor: (cursor) =>
+      persistSyncCursor(context, cursor, "googleContent.persistCursor"),
+    markSnapshotPending: () => setSelectionSnapshotPending(context, true),
+    runSelectionSnapshot: () =>
+      reconcileSelectionSnapshot(context, client, counters),
+    clearSnapshotPending: () => setSelectionSnapshotPending(context, false),
+  });
 }
 
 async function markConnectorAccessLost(connectorId: string): Promise<void> {
@@ -1739,6 +1851,23 @@ async function resolveSyncCursor(
 ): Promise<string> {
   if (!context.connector.cursor) {
     return reconcileInitial(context, client, counters);
+  }
+  // An earlier run advanced its cursor past a page that obligated a selection
+  // snapshot but did not finish (or even reach) that snapshot. Discharge the
+  // obligation before consuming anything new — the cursor no longer carries
+  // that information.
+  if (isSelectionSnapshotPending(context.connector.metadata)) {
+    log.info("Resuming a pending Google Drive selection snapshot", {
+      connectorId: context.connector.id,
+      runId,
+      pendingSince:
+        context.connector.metadata.selectionSnapshotPendingAt ?? null,
+    });
+    await resumePendingSelectionSnapshot({
+      runSelectionSnapshot: () =>
+        reconcileSelectionSnapshot(context, client, counters),
+      clearSnapshotPending: () => setSelectionSnapshotPending(context, false),
+    });
   }
   try {
     return await reconcileChanges(

--- a/infra/lambdas/google-content-sync/index.ts
+++ b/infra/lambdas/google-content-sync/index.ts
@@ -1059,14 +1059,28 @@ async function enumerateInitialFiles(
         recordUnreadable("enumerateSelection", selection.externalId, error);
         continue;
       }
-      if (
-        selection.selectionKind !== "drive" &&
-        isGoogleDriveMissingError(error)
-      ) {
+      if (isGoogleDriveMissingError(error)) {
+        // Scoped to the selection that is gone, INCLUDING a `drive` selection.
+        // Rethrowing for drives used to escalate one removed Shared Drive into
+        // connector-wide access loss: `handleSyncFailure` calls
+        // `markConnectorAccessLost`, which marks every source on the connector
+        // — file and folder selections that are still perfectly readable
+        // included — and the deletion grace period then removes their content.
+        // Continuing instead lets the snapshot finish and hands retirement to
+        // `markUnseenSourcesMissing`, which only retires what this enumeration
+        // did not see. That is what the drive-removal change handler already
+        // documents as the recovery path, and it keeps an individually shared
+        // file that happens to live in the removed drive alive as long as some
+        // other selection still reaches it.
+        //
+        // A total loss of access still converges: every selection lands here,
+        // the seen set is empty, and the sweep retires all sources into the
+        // same grace period `markConnectorAccessLost` would have used.
         inaccessibleSelectionCount += 1;
         log.error("Google Drive selection is no longer accessible", {
           connectorId: context.connector.id,
           selectionId: selection.id,
+          selectionKind: selection.selectionKind,
           errorCode: sourceFailureCode(error),
         });
         continue;
@@ -1495,9 +1509,10 @@ async function processGoogleDriveChange(
     // A removal, though, is not noise: the Shared Drive was deleted or this
     // account lost access, so sources imported from it are now unreachable.
     // Requesting a selection snapshot lets markUnseenSourcesMissing retire
-    // them; a hard access loss still surfaces through the existing 403/404
-    // path. Anything else is metadata noise and is skipped without side
-    // effects so the cursor keeps advancing.
+    // them, scoped to that drive: enumerateInitialFiles treats the now-403/404
+    // drive selection as inaccessible and carries on, so sources reached by
+    // other selections stay untouched. Anything else is metadata noise and is
+    // skipped without side effects so the cursor keeps advancing.
     const driveRemoved = isDriveRemovalChange(change);
     log.info(
       driveRemoved

--- a/infra/lambdas/google-content-sync/index.ts
+++ b/infra/lambdas/google-content-sync/index.ts
@@ -76,6 +76,7 @@ import {
 } from "../../../lib/repositories/google-drive/formats";
 import { refreshGoogleAccessToken } from "../../../lib/repositories/google-drive/oauth";
 import { getGoogleContentWifAccessToken } from "../../../lib/repositories/google-drive/wif";
+import { isFileScopedDriveChange } from "./changes";
 import {
   assertGoogleSourceMetadataSize,
   assertGoogleSourceResponseSize,
@@ -1332,12 +1333,49 @@ type GoogleDriveChange = Awaited<
   ReturnType<GoogleDriveClient["listChanges"]>
 >["values"][number];
 
+/**
+ * Records the outcome of a failed file-scoped change. Connector lifecycle
+ * errors are fatal to the whole run and are rethrown; a Drive 403/404 means the
+ * file was deleted or access was lost, which is the markSourceMissing path.
+ * Anything else is rethrown so the caller can fail the record.
+ */
+async function recordDriveChangeFailure(
+  context: ConnectorContext,
+  fileId: string,
+  error: unknown,
+  counters: SyncCounters,
+): Promise<void> {
+  if (
+    error instanceof ConnectorRevokedError ||
+    error instanceof ConnectorPausedError ||
+    error instanceof ConnectorSelectionChangedError
+  ) {
+    throw error;
+  }
+  if (!isGoogleDriveMissingError(error)) throw error;
+  if (await markSourceMissing(context, fileId)) {
+    counters.missing += 1;
+  } else {
+    counters.failed += 1;
+  }
+}
+
 async function processGoogleDriveChange(
   context: ConnectorContext,
   client: GoogleDriveClient,
   change: GoogleDriveChange,
   counters: SyncCounters,
 ): Promise<boolean> {
+  // Shared Drive-scoped entries (rename, membership, restriction changes) have
+  // no fileId. Nothing below can act on them, and they must not stall the
+  // cursor: skip without side effects so the loop keeps advancing.
+  if (!isFileScopedDriveChange(change)) {
+    log.info("Skipped non-file Google Drive change entry", {
+      connectorId: context.connector.id,
+      changeType: change.changeType ?? null,
+    });
+    return false;
+  }
   if (change.removed || !change.file || change.file.trashed) {
     if (await markSourceMissing(context, change.fileId)) {
       counters.missing += 1;
@@ -1363,21 +1401,7 @@ async function processGoogleDriveChange(
     );
     return false;
   } catch (error) {
-    if (
-      error instanceof ConnectorRevokedError ||
-      error instanceof ConnectorPausedError ||
-      error instanceof ConnectorSelectionChangedError
-    ) {
-      throw error;
-    }
-    if (!isGoogleDriveMissingError(error)) throw error;
-    if (
-      await markSourceMissing(context, change.fileId)
-    ) {
-      counters.missing += 1;
-    } else {
-      counters.failed += 1;
-    }
+    await recordDriveChangeFailure(context, change.fileId, error, counters);
     return false;
   }
 }

--- a/infra/lambdas/google-content-sync/reconcile.ts
+++ b/infra/lambdas/google-content-sync/reconcile.ts
@@ -1,0 +1,130 @@
+/**
+ * The changes-feed reconcile loop, expressed against injected collaborators
+ * so it can be exercised without a database, Google credentials, or the
+ * Lambda's module-level environment requirements.
+ *
+ * The invariant this module exists to protect: the cursor advances page by
+ * page, ALWAYS, and the obligation to rebuild the selection snapshot is
+ * recorded durably instead of being implied by a cursor that was left behind.
+ *
+ * Before this split, a page that demanded a snapshot suppressed every
+ * per-page cursor write until the snapshot finished. A 900s Lambda timeout or
+ * a snapshot budget failure therefore threw away all the change-page work and
+ * replayed it from the original cursor on the next attempt — indefinitely, if
+ * the snapshot kept failing.
+ */
+
+/** The connector-metadata slice that carries the snapshot obligation. */
+export interface SnapshotObligationMetadata {
+  selectionSnapshotPendingAt?: string;
+}
+
+export function isSelectionSnapshotPending(
+  metadata: SnapshotObligationMetadata | null | undefined,
+): boolean {
+  return typeof metadata?.selectionSnapshotPendingAt === "string";
+}
+
+/** The jsonb key the durable flag is stored under. */
+export const SELECTION_SNAPSHOT_PENDING_KEY = "selectionSnapshotPendingAt";
+
+/**
+ * Retiring sources that a snapshot did not see is only sound after a COMPLETE
+ * enumeration.
+ *
+ * Per-entry validation drops entries Google returned in a shape this client
+ * cannot read. A dropped entry says nothing about whether its file still
+ * exists, so a file could be absent from the seen set purely because one
+ * record was unreadable — and marking it missing would be silent data loss.
+ * When anything was dropped, the sweep is skipped and left to the next clean
+ * snapshot.
+ */
+export function shouldRetireUnseenSources(enumeration: {
+  skippedEntryCount: number;
+}): boolean {
+  return enumeration.skippedEntryCount === 0;
+}
+
+export interface ChangesPage<TChange> {
+  values: TChange[];
+  nextPageToken: string | null;
+  newStartPageToken: string | null;
+}
+
+export interface ReconcileChangesDeps<TChange> {
+  listChanges(cursor: string): Promise<ChangesPage<TChange>>;
+  /**
+   * Handles one change entry. Returns true when the entry obligates a full
+   * selection snapshot (a Shared Drive went away).
+   */
+  processChange(change: TChange): Promise<boolean>;
+  /** Advance the durable cursor. */
+  persistCursor(cursor: string): Promise<void>;
+  /** Record the snapshot obligation durably. Called at most once per run. */
+  markSnapshotPending(): Promise<void>;
+  /**
+   * Re-enumerate every selection and retire whatever is unreachable. Resolves
+   * false when the enumeration was incomplete, in which case the unseen-source
+   * sweep did not run and the obligation is NOT discharged.
+   */
+  runSelectionSnapshot(): Promise<boolean>;
+  /** Clear the durable obligation. Only ever called after a complete snapshot. */
+  clearSnapshotPending(): Promise<void>;
+}
+
+export type ResumeSnapshotDeps = Pick<
+  ReconcileChangesDeps<never>,
+  "runSelectionSnapshot" | "clearSnapshotPending"
+>;
+
+/**
+ * Discharge a snapshot obligation left behind by an earlier run, before any
+ * new change page is consumed. The flag is cleared only once the snapshot has
+ * completed, so a repeated failure repeats the snapshot rather than silently
+ * dropping the obligation.
+ */
+export async function resumePendingSelectionSnapshot(
+  deps: ResumeSnapshotDeps,
+): Promise<boolean> {
+  const complete = await deps.runSelectionSnapshot();
+  if (complete) await deps.clearSnapshotPending();
+  return complete;
+}
+
+/**
+ * Consume the changes feed from `initialCursor` and return the cursor to
+ * persist as the run's result.
+ *
+ * Ordering rules, in the order they matter:
+ *  1. A snapshot obligation is written BEFORE the cursor moves past the page
+ *     that raised it. A crash between the two can only replay work, never
+ *     lose the obligation.
+ *  2. The cursor is persisted after every page, unconditionally.
+ *  3. The snapshot runs after the feed is drained, and the flag is cleared
+ *     only when it succeeded.
+ */
+export async function reconcileChangePages<TChange>(
+  initialCursor: string,
+  deps: ReconcileChangesDeps<TChange>,
+): Promise<string> {
+  let cursor = initialCursor;
+  let requiresSelectionSnapshot = false;
+  for (;;) {
+    const page = await deps.listChanges(cursor);
+    for (const change of page.values) {
+      const demandsSnapshot = await deps.processChange(change);
+      if (demandsSnapshot && !requiresSelectionSnapshot) {
+        requiresSelectionSnapshot = true;
+        // Rule 1: durable before the cursor moves past this page.
+        await deps.markSnapshotPending();
+      }
+    }
+    cursor = page.nextPageToken ?? page.newStartPageToken ?? cursor;
+    await deps.persistCursor(cursor);
+    if (!page.nextPageToken) break;
+  }
+  if (requiresSelectionSnapshot) {
+    await resumePendingSelectionSnapshot(deps);
+  }
+  return cursor;
+}

--- a/infra/lambdas/google-content-sync/tsconfig.json
+++ b/infra/lambdas/google-content-sync/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "incremental": false,
+    "types": ["node", "aws-lambda"]
+  },
+  "include": ["./*.ts", "../../../next-env.d.ts"],
+  "exclude": ["./__tests__"]
+}

--- a/infra/package.json
+++ b/infra/package.json
@@ -5,13 +5,14 @@
     "infra": "bin/infra.js"
   },
   "scripts": {
-    "build": "tsc && bun run typecheck:unified-content && bun run test:lambdas",
+    "build": "tsc && bun run typecheck:unified-content && bun run typecheck:google-content-sync && bun run test:lambdas",
     "build:lambdas": "./build-lambdas.sh",
     "build:all": "bun run build && bun run build:lambdas",
     "watch": "tsc -w",
     "test": "jest",
     "test:lambdas": "bun test lambdas/embedding-generator/__tests__ && cd lambdas/agent-skill-builder && bun install && bun run test",
     "typecheck:unified-content": "tsc --project lambdas/unified-content-processor/tsconfig.json",
+    "typecheck:google-content-sync": "tsc --project lambdas/google-content-sync/tsconfig.json",
     "cdk": "cdk"
   },
   "devDependencies": {

--- a/lib/db/schema/tables/repository-connectors.ts
+++ b/lib/db/schema/tables/repository-connectors.ts
@@ -42,6 +42,16 @@ export interface RepositoryConnectorMetadata {
   oauthEmail?: string;
   googleDriveName?: string;
   lastNotificationState?: string;
+  /**
+   * ISO timestamp set when a change page has obligated the connector to
+   * rebuild its selection snapshot, and cleared once that snapshot completes.
+   *
+   * The obligation must outlive the process: without it, the only record that
+   * a snapshot was owed was the un-advanced cursor, so a Lambda timeout or a
+   * snapshot budget failure forced every already-processed change page to be
+   * re-fetched and re-processed on the next attempt.
+   */
+  selectionSnapshotPendingAt?: string;
 }
 
 export interface RepositoryConnectorSourceMetadata {

--- a/lib/repositories/google-drive/drive-client.ts
+++ b/lib/repositories/google-drive/drive-client.ts
@@ -24,36 +24,97 @@ const FILE_FIELDS = [
   "shortcutDetails(targetId,targetMimeType,targetResourceKey)",
 ].join(",");
 
-const driveUserSchema = z.object({ displayName: z.string().optional() });
+/**
+ * Google omits absent fields far more often than it nulls them, but an
+ * explicit `null` must never fail a whole page. `nullish` + a normalizing
+ * transform keeps the parsed shape identical to the previous `optional()`
+ * output while tolerating both encodings.
+ */
+const optionalString = z
+  .string()
+  .nullish()
+  .transform((value) => value ?? undefined)
+  .optional();
+
+/**
+ * Link fields are stored as source metadata and are candidates for rendering
+ * as an href. They are deliberately NOT validated with a strict URL parser —
+ * a link Google formats unexpectedly must not stall the connector — but a
+ * non-http(s) scheme (`javascript:`, `data:`) is dropped rather than
+ * persisted, so loosening the validator cannot open an injection path.
+ */
+const optionalWebUrl = z
+  .string()
+  .nullish()
+  .transform((value) =>
+    value && /^https?:\/\//i.test(value) ? value : undefined,
+  )
+  .optional();
+
+const optionalBoolean = (fallback: boolean) =>
+  z
+    .boolean()
+    .nullish()
+    .transform((value) => value ?? fallback);
+
+const driveUserSchema = z.object({ displayName: optionalString });
+
+/**
+ * Only `targetId` is consumed (`resolveShortcut` dereferences it and raises a
+ * graceful "no target" error when it is absent). `targetMimeType` has no
+ * reader anywhere in the codebase, so requiring it could only ever turn a
+ * complete page into a poison message — it is optional and unused.
+ */
 const shortcutDetailsSchema = z.object({
-  targetId: z.string(),
-  targetMimeType: z.string(),
-  targetResourceKey: z.string().optional(),
+  targetId: optionalString,
+  targetMimeType: optionalString,
+  targetResourceKey: optionalString,
 });
 
 export const googleDriveFileSchema = z.object({
   id: z.string(),
   name: z.string(),
   mimeType: z.string(),
-  parents: z.array(z.string()).optional().default([]),
-  driveId: z.string().optional(),
-  modifiedTime: z.string().datetime({ offset: true }).optional(),
-  md5Checksum: z.string().optional(),
-  version: z.string().optional(),
-  headRevisionId: z.string().optional(),
-  size: z.string().regex(/^\d+$/).optional(),
-  trashed: z.boolean().optional().default(false),
-  webViewLink: z.string().url().optional(),
-  iconLink: z.string().url().optional(),
-  owners: z.array(driveUserSchema).optional().default([]),
-  shortcutDetails: shortcutDetailsSchema.optional(),
+  parents: z
+    .array(z.string())
+    .nullish()
+    .transform((value) => value ?? []),
+  driveId: optionalString,
+  // Plain string, not `.datetime()`: the only consumers are `new Date(...)`
+  // and a revision string. Callers guard invalid dates themselves.
+  modifiedTime: optionalString,
+  md5Checksum: optionalString,
+  version: optionalString,
+  headRevisionId: optionalString,
+  // The numeric shape is re-checked by `assertGoogleSourceMetadataSize`, and
+  // the streaming byte bound is authoritative regardless of what Drive
+  // reports here.
+  size: optionalString,
+  trashed: optionalBoolean(false),
+  webViewLink: optionalWebUrl,
+  iconLink: optionalWebUrl,
+  owners: z
+    .array(driveUserSchema)
+    .nullish()
+    .transform((value) => value ?? []),
+  shortcutDetails: shortcutDetailsSchema.nullish(),
 });
 
 export type GoogleDriveFile = z.infer<typeof googleDriveFileSchema>;
 
+/**
+ * List envelopes are parsed with UNVALIDATED entries so a single malformed
+ * member cannot reject the page. Each entry is validated on its own by
+ * {@link parseDriveEntries}.
+ */
+const rawEntriesSchema = z
+  .array(z.unknown())
+  .nullish()
+  .transform((value) => value ?? []);
+
 const filesListSchema = z.object({
-  nextPageToken: z.string().optional(),
-  files: z.array(googleDriveFileSchema).default([]),
+  nextPageToken: optionalString,
+  files: rawEntriesSchema,
 });
 
 /**
@@ -67,18 +128,18 @@ const filesListSchema = z.object({
  * value Google adds later must not re-poison the queue.
  */
 const driveChangeSchema = z.object({
-  changeType: z.string().optional(),
-  fileId: z.string().optional(),
-  removed: z.boolean().optional().default(false),
-  time: z.string().datetime({ offset: true }).optional(),
-  driveId: z.string().optional(),
-  file: googleDriveFileSchema.optional(),
+  changeType: optionalString,
+  fileId: optionalString,
+  removed: optionalBoolean(false),
+  time: optionalString,
+  driveId: optionalString,
+  file: googleDriveFileSchema.nullish(),
 });
 
 const changesListSchema = z.object({
-  nextPageToken: z.string().optional(),
-  newStartPageToken: z.string().optional(),
-  changes: z.array(driveChangeSchema).default([]),
+  nextPageToken: optionalString,
+  newStartPageToken: optionalString,
+  changes: rawEntriesSchema,
 });
 
 const startPageTokenSchema = z.object({ startPageToken: z.string() });
@@ -106,13 +167,74 @@ const downloadOperationSchema = z.object({
 
 export type GoogleDriveChange = z.infer<typeof driveChangeSchema>;
 
+/**
+ * A single list entry Google returned that this client could not validate.
+ *
+ * The entry is DROPPED, never reinterpreted: a parse failure says nothing
+ * about whether the underlying Drive file still exists, so treating it as a
+ * removal would trade a stalled connector for silent data loss. The cost of
+ * dropping it is that the file's latest change is missed until it changes
+ * again (or a selection snapshot re-enumerates it) — which is why every
+ * skipped entry is reported to the caller for logging.
+ */
+export interface GoogleDriveSkippedEntry {
+  /** Position within the page, so repeat offenders are identifiable. */
+  index: number;
+  /** `id` / `fileId` / `file.id` when one of them was extractable. */
+  id: string | null;
+  issues: Array<{ path: string; message: string }>;
+}
+
 export interface GoogleDriveListPage<T> {
   values: T[];
   nextPageToken: string | null;
+  /** Entries dropped by per-entry validation. Empty on a healthy page. */
+  skippedEntries: GoogleDriveSkippedEntry[];
 }
 
 export interface GoogleDriveChangesPage extends GoogleDriveListPage<GoogleDriveChange> {
   newStartPageToken: string | null;
+}
+
+function extractEntryId(entry: unknown): string | null {
+  if (typeof entry !== "object" || entry === null) return null;
+  const record = entry as Record<string, unknown>;
+  if (typeof record.id === "string") return record.id;
+  if (typeof record.fileId === "string") return record.fileId;
+  const file = record.file;
+  if (typeof file === "object" && file !== null) {
+    const nested = (file as Record<string, unknown>).id;
+    if (typeof nested === "string") return nested;
+  }
+  return null;
+}
+
+/**
+ * Validate list entries one at a time. One malformed member of a 1000-entry
+ * page costs that one entry, not the page — and therefore not the cursor.
+ */
+function parseDriveEntries<T>(
+  schema: z.ZodType<T>,
+  entries: readonly unknown[],
+): { values: T[]; skippedEntries: GoogleDriveSkippedEntry[] } {
+  const values: T[] = [];
+  const skippedEntries: GoogleDriveSkippedEntry[] = [];
+  for (const [index, entry] of entries.entries()) {
+    const result = schema.safeParse(entry);
+    if (result.success) {
+      values.push(result.data);
+      continue;
+    }
+    skippedEntries.push({
+      index,
+      id: extractEntryId(entry),
+      issues: result.error.issues.map((issue) => ({
+        path: issue.path.join("."),
+        message: issue.message,
+      })),
+    });
+  }
+  return { values, skippedEntries };
 }
 
 export interface GoogleDriveWatch {
@@ -232,9 +354,11 @@ export class GoogleDriveClient {
     if (pageToken) url.searchParams.set("pageToken", pageToken);
     const response = await this.request(url);
     const page = filesListSchema.parse(await response.json());
+    const parsed = parseDriveEntries(googleDriveFileSchema, page.files);
     return {
-      values: page.files,
+      values: parsed.values,
       nextPageToken: page.nextPageToken ?? null,
+      skippedEntries: parsed.skippedEntries,
     };
   }
 
@@ -253,9 +377,11 @@ export class GoogleDriveClient {
     if (pageToken) url.searchParams.set("pageToken", pageToken);
     const response = await this.request(url);
     const page = filesListSchema.parse(await response.json());
+    const parsed = parseDriveEntries(googleDriveFileSchema, page.files);
     return {
-      values: page.files,
+      values: parsed.values,
       nextPageToken: page.nextPageToken ?? null,
+      skippedEntries: parsed.skippedEntries,
     };
   }
 
@@ -286,10 +412,12 @@ export class GoogleDriveClient {
     }
     const response = await this.request(url);
     const page = changesListSchema.parse(await response.json());
+    const parsed = parseDriveEntries(driveChangeSchema, page.changes);
     return {
-      values: page.changes,
+      values: parsed.values,
       nextPageToken: page.nextPageToken ?? null,
       newStartPageToken: page.newStartPageToken ?? null,
+      skippedEntries: parsed.skippedEntries,
     };
   }
 

--- a/lib/repositories/google-drive/drive-client.ts
+++ b/lib/repositories/google-drive/drive-client.ts
@@ -80,8 +80,10 @@ const optionalBoolean = (fallback: boolean) =>
 const driveUserSchema = z.object({ displayName: optionalString });
 
 /**
- * Only `targetId` is consumed (`resolveShortcut` dereferences it and raises a
- * graceful "no target" error when it is absent). `targetMimeType` has no
+ * Only `targetId` is consumed. `resolveShortcut` dereferences it and, when it
+ * is absent, throws a typed {@link GoogleDriveUnreadableFileError} that both
+ * of its call sites already classify as a per-entry skip — making the field
+ * optional here therefore costs one entry, never the page. `targetMimeType` has no
  * reader anywhere in the codebase, so requiring it could only ever turn a
  * complete page into a poison message — it is optional and unused.
  */

--- a/lib/repositories/google-drive/drive-client.ts
+++ b/lib/repositories/google-drive/drive-client.ts
@@ -51,6 +51,26 @@ const optionalWebUrl = z
   )
   .optional();
 
+/**
+ * Timestamps are consumed with `new Date(...)` and land in a `timestamp`
+ * column. Neither extreme is safe on its own: a strict `.datetime()` would
+ * turn one malformed value into a rejected entry (the poison-page class this
+ * client exists to prevent), while passing an unparseable string straight
+ * through is worse than dropping it — `new Date("not-a-date")` is an Invalid
+ * Date, the import transaction fails on the timestamp column, and because the
+ * entry *validated* the snapshot never counts it as skipped. The cursor
+ * advances, the unseen-source sweep is not suppressed, and the file stays
+ * unimported indefinitely. So: accept anything Google sends, keep only what
+ * actually parses, and let the field fall back to its absent behaviour.
+ */
+const optionalTimestamp = z
+  .string()
+  .nullish()
+  .transform((value) =>
+    value && !Number.isNaN(Date.parse(value)) ? value : undefined,
+  )
+  .optional();
+
 const optionalBoolean = (fallback: boolean) =>
   z
     .boolean()
@@ -80,9 +100,10 @@ export const googleDriveFileSchema = z.object({
     .nullish()
     .transform((value) => value ?? []),
   driveId: optionalString,
-  // Plain string, not `.datetime()`: the only consumers are `new Date(...)`
-  // and a revision string. Callers guard invalid dates themselves.
-  modifiedTime: optionalString,
+  // Lenient, but not blindly so: an unparseable value is dropped rather than
+  // handed to `new Date(...)` on the way into a timestamp column. See
+  // `optionalTimestamp`.
+  modifiedTime: optionalTimestamp,
   md5Checksum: optionalString,
   version: optionalString,
   headRevisionId: optionalString,

--- a/lib/repositories/google-drive/drive-client.ts
+++ b/lib/repositories/google-drive/drive-client.ts
@@ -56,8 +56,19 @@ const filesListSchema = z.object({
   files: z.array(googleDriveFileSchema).default([]),
 });
 
+/**
+ * Google's Changes feed is not exclusively file-scoped. Entries with
+ * `changeType: "drive"` describe the Shared Drive itself (rename, membership,
+ * restriction changes) and carry NO `fileId`. Requiring `fileId` here made
+ * every such entry a poison message: `listChanges` threw before the cursor
+ * advanced, so the Lambda retried the same page forever.
+ *
+ * `changeType` is deliberately a plain string rather than an enum — a new
+ * value Google adds later must not re-poison the queue.
+ */
 const driveChangeSchema = z.object({
-  fileId: z.string(),
+  changeType: z.string().optional(),
+  fileId: z.string().optional(),
   removed: z.boolean().optional().default(false),
   time: z.string().datetime({ offset: true }).optional(),
   driveId: z.string().optional(),
@@ -267,7 +278,7 @@ export class GoogleDriveClient {
     url.searchParams.set("includeItemsFromAllDrives", "true");
     url.searchParams.set(
       "fields",
-      `nextPageToken,newStartPageToken,changes(fileId,removed,time,driveId,file(${FILE_FIELDS}))`,
+      `nextPageToken,newStartPageToken,changes(changeType,fileId,removed,time,driveId,file(${FILE_FIELDS}))`,
     );
     if (driveId) {
       url.searchParams.set("driveId", driveId);

--- a/lib/repositories/google-drive/drive-client.ts
+++ b/lib/repositories/google-drive/drive-client.ts
@@ -209,6 +209,15 @@ function extractEntryId(entry: unknown): string | null {
   return null;
 }
 
+function formatEntryIssues(
+  error: z.ZodError,
+): Array<{ path: string; message: string }> {
+  return error.issues.map((issue) => ({
+    path: issue.path.join("."),
+    message: issue.message,
+  }));
+}
+
 /**
  * Validate list entries one at a time. One malformed member of a 1000-entry
  * page costs that one entry, not the page — and therefore not the cursor.
@@ -228,10 +237,7 @@ function parseDriveEntries<T>(
     skippedEntries.push({
       index,
       id: extractEntryId(entry),
-      issues: result.error.issues.map((issue) => ({
-        path: issue.path.join("."),
-        message: issue.message,
-      })),
+      issues: formatEntryIssues(result.error),
     });
   }
   return { values, skippedEntries };
@@ -263,6 +269,25 @@ export class GoogleDriveDownloadPendingError extends Error {
   constructor(public readonly operationName: string) {
     super("Google Drive download is still preparing");
     this.name = "GoogleDriveDownloadPendingError";
+  }
+}
+
+/**
+ * `getFile` returned 200 but the body failed validation — the single-entity
+ * sibling of a dropped list entry.
+ *
+ * Distinct from {@link GoogleDriveApiError} because the correct handling is
+ * the opposite of a 403/404: the file very likely still exists, so callers
+ * must fail or skip the one record — never mark its source missing, and never
+ * let the error escape far enough to stall a change page's cursor.
+ */
+export class GoogleDriveUnreadableFileError extends Error {
+  constructor(
+    public readonly fileId: string,
+    public readonly issues: Array<{ path: string; message: string }>,
+  ) {
+    super(`Google Drive returned an unreadable record for file ${fileId}`);
+    this.name = "GoogleDriveUnreadableFileError";
   }
 }
 
@@ -335,7 +360,14 @@ export class GoogleDriveClient {
           }
         : undefined,
     );
-    return googleDriveFileSchema.parse(await response.json());
+    const parsed = googleDriveFileSchema.safeParse(await response.json());
+    if (!parsed.success) {
+      throw new GoogleDriveUnreadableFileError(
+        fileId,
+        formatEntryIssues(parsed.error),
+      );
+    }
+    return parsed.data;
   }
 
   async listChildren(

--- a/tests/unit/google-content-sync-change-scope.test.ts
+++ b/tests/unit/google-content-sync-change-scope.test.ts
@@ -1,0 +1,94 @@
+/** @jest-environment node */
+
+import fs from "node:fs";
+import path from "node:path";
+import {
+  DRIVE_SCOPED_CHANGE_TYPE,
+  isFileScopedDriveChange,
+} from "../../infra/lambdas/google-content-sync/changes";
+import { stripComments } from "../helpers/strip-ts-comments";
+
+describe("Google Drive change scope classification", () => {
+  test("skips Shared Drive-scoped entries even when a fileId is present", () => {
+    expect(
+      isFileScopedDriveChange({ changeType: DRIVE_SCOPED_CHANGE_TYPE }),
+    ).toBe(false);
+    expect(
+      isFileScopedDriveChange({
+        changeType: DRIVE_SCOPED_CHANGE_TYPE,
+        fileId: "file-1",
+      }),
+    ).toBe(false);
+  });
+
+  test("skips entries with a missing or empty fileId", () => {
+    expect(isFileScopedDriveChange({})).toBe(false);
+    expect(isFileScopedDriveChange({ changeType: "file" })).toBe(false);
+    expect(isFileScopedDriveChange({ fileId: "" })).toBe(false);
+    expect(isFileScopedDriveChange({ fileId: undefined })).toBe(false);
+  });
+
+  test("processes file-scoped entries, including ones with no changeType", () => {
+    expect(isFileScopedDriveChange({ changeType: "file", fileId: "f1" })).toBe(
+      true,
+    );
+    expect(isFileScopedDriveChange({ fileId: "f1" })).toBe(true);
+  });
+
+  test("treats unknown change types as file-scoped when a fileId is present", () => {
+    // A future changeType value must not become a poison message: if Google
+    // gave us a fileId, the file path can still act on it.
+    expect(
+      isFileScopedDriveChange({ changeType: "someFutureScope", fileId: "f1" }),
+    ).toBe(true);
+    expect(isFileScopedDriveChange({ changeType: "someFutureScope" })).toBe(
+      false,
+    );
+  });
+
+  test("narrows fileId to a string for the file-scoped branch", () => {
+    const change: { changeType?: string; fileId?: string } = {
+      changeType: "file",
+      fileId: "file-1",
+    };
+    if (isFileScopedDriveChange(change)) {
+      const fileId: string = change.fileId;
+      expect(fileId).toBe("file-1");
+    } else {
+      throw new Error("expected the entry to be file-scoped");
+    }
+  });
+});
+
+describe("processGoogleDriveChange guard wiring", () => {
+  const source = stripComments(
+    fs.readFileSync(
+      path.join(process.cwd(), "infra/lambdas/google-content-sync/index.ts"),
+      "utf8",
+    ),
+  );
+
+  test("guards the change handler before any file-scoped work", () => {
+    const body = source.slice(
+      source.indexOf("async function processGoogleDriveChange("),
+    );
+    const guardIndex = body.indexOf("isFileScopedDriveChange(change)");
+    const firstSideEffect = body.indexOf("markSourceMissing(");
+
+    expect(guardIndex).toBeGreaterThan(-1);
+    expect(firstSideEffect).toBeGreaterThan(-1);
+    // The skip must come first: nothing downstream can act on a fileId-less
+    // entry, and the reconcile loop still advances the cursor afterwards.
+    expect(guardIndex).toBeLessThan(firstSideEffect);
+  });
+
+  test("the reconcile loop persists the cursor for skipped entries", () => {
+    const loop = source.slice(
+      source.indexOf("async function reconcileChanges("),
+    );
+    // processGoogleDriveChange returns false for a skipped entry, which leaves
+    // requiresSelectionSnapshot false, so persistSyncCursor runs each page.
+    expect(loop).toContain("if (!requiresSelectionSnapshot) {");
+    expect(loop).toContain("await persistSyncCursor(");
+  });
+});

--- a/tests/unit/google-content-sync-change-scope.test.ts
+++ b/tests/unit/google-content-sync-change-scope.test.ts
@@ -151,18 +151,17 @@ describe("processGoogleDriveChange guard wiring", () => {
     expect(body).toContain("return driveRemoved;");
   });
 
-  test("the reconcile loop persists the cursor on both skip and removal", () => {
+  test("the reconcile loop is the shared, behaviorally tested one", () => {
+    // The cursor/obligation ordering itself is proven in
+    // google-content-sync-reconcile.test.ts against the real loop. All this
+    // asserts is that index.ts still delegates to it rather than growing a
+    // second copy.
     const loop = source.slice(
       source.indexOf("async function reconcileChanges("),
       source.indexOf("async function markConnectorAccessLost("),
     );
-    // Skipped entry: returns false, requiresSelectionSnapshot stays false, so
-    // the per-page persist runs.
-    expect(loop).toContain("if (!requiresSelectionSnapshot) {");
-    // Removal: returns true, so the cursor is persisted after the snapshot.
-    expect(loop).toContain("if (requiresSelectionSnapshot) {");
-    expect(loop).toContain("await reconcileSelectionSnapshot(");
-    // Either way the cursor advances — that is the invariant the outage broke.
-    expect(loop.match(/await persistSyncCursor\(/g)).toHaveLength(2);
+    expect(loop).toContain("return reconcileChangePages<GoogleDriveChange>(");
+    expect(loop).toContain("runSelectionSnapshot:");
+    expect(loop).toContain("markSnapshotPending:");
   });
 });

--- a/tests/unit/google-content-sync-change-scope.test.ts
+++ b/tests/unit/google-content-sync-change-scope.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import {
   DRIVE_SCOPED_CHANGE_TYPE,
+  isDriveRemovalChange,
   isFileScopedDriveChange,
 } from "../../infra/lambdas/google-content-sync/changes";
 import { stripComments } from "../helpers/strip-ts-comments";
@@ -60,6 +61,63 @@ describe("Google Drive change scope classification", () => {
   });
 });
 
+describe("Shared Drive removal detection", () => {
+  test("flags a drive-scoped removal so the caller rebuilds the selection", () => {
+    // The Shared Drive was deleted or access was lost. Sources imported from
+    // it are unreachable, and a connector reading the global changes feed gets
+    // no other signal — its later listChanges calls keep succeeding.
+    expect(
+      isDriveRemovalChange({
+        changeType: DRIVE_SCOPED_CHANGE_TYPE,
+        removed: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("covers legacy and future drive-like scopes, not just \"drive\"", () => {
+    expect(
+      isDriveRemovalChange({ changeType: "teamDrive", removed: true }),
+    ).toBe(true);
+    expect(
+      isDriveRemovalChange({ changeType: "someFutureScope", removed: true }),
+    ).toBe(true);
+    expect(isDriveRemovalChange({ removed: true })).toBe(true);
+  });
+
+  test("ignores drive-scoped metadata noise", () => {
+    // Rename, membership and restriction changes carry removed: false.
+    expect(
+      isDriveRemovalChange({
+        changeType: DRIVE_SCOPED_CHANGE_TYPE,
+        removed: false,
+      }),
+    ).toBe(false);
+    expect(
+      isDriveRemovalChange({ changeType: DRIVE_SCOPED_CHANGE_TYPE }),
+    ).toBe(false);
+  });
+
+  test("never claims a file-scoped removal — that is the file path's job", () => {
+    expect(
+      isDriveRemovalChange({
+        changeType: "file",
+        fileId: "file-1",
+        removed: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("treats a drive-scoped entry that also carries a fileId as drive-scoped", () => {
+    expect(
+      isDriveRemovalChange({
+        changeType: DRIVE_SCOPED_CHANGE_TYPE,
+        fileId: "file-1",
+        removed: true,
+      }),
+    ).toBe(true);
+  });
+});
+
 describe("processGoogleDriveChange guard wiring", () => {
   const source = stripComments(
     fs.readFileSync(
@@ -82,13 +140,29 @@ describe("processGoogleDriveChange guard wiring", () => {
     expect(guardIndex).toBeLessThan(firstSideEffect);
   });
 
-  test("the reconcile loop persists the cursor for skipped entries", () => {
+  test("propagates the removal signal instead of swallowing it", () => {
+    const body = source.slice(
+      source.indexOf("async function processGoogleDriveChange("),
+    );
+    // A drive removal must return true so reconcileChanges rebuilds the
+    // selection snapshot; returning a bare false here would strand every
+    // source imported from the drive that went away.
+    expect(body).toContain("isDriveRemovalChange(change)");
+    expect(body).toContain("return driveRemoved;");
+  });
+
+  test("the reconcile loop persists the cursor on both skip and removal", () => {
     const loop = source.slice(
       source.indexOf("async function reconcileChanges("),
+      source.indexOf("async function markConnectorAccessLost("),
     );
-    // processGoogleDriveChange returns false for a skipped entry, which leaves
-    // requiresSelectionSnapshot false, so persistSyncCursor runs each page.
+    // Skipped entry: returns false, requiresSelectionSnapshot stays false, so
+    // the per-page persist runs.
     expect(loop).toContain("if (!requiresSelectionSnapshot) {");
-    expect(loop).toContain("await persistSyncCursor(");
+    // Removal: returns true, so the cursor is persisted after the snapshot.
+    expect(loop).toContain("if (requiresSelectionSnapshot) {");
+    expect(loop).toContain("await reconcileSelectionSnapshot(");
+    // Either way the cursor advances — that is the invariant the outage broke.
+    expect(loop.match(/await persistSyncCursor\(/g)).toHaveLength(2);
   });
 });

--- a/tests/unit/google-content-sync-change-scope.test.ts
+++ b/tests/unit/google-content-sync-change-scope.test.ts
@@ -185,6 +185,24 @@ describe("processGoogleDriveChange guard wiring", () => {
     expect(body).toContain("recordSourceFailure(context, fileId, error)");
   });
 
+  test("a shortcut with no target fails typed, so it cannot poison a page", () => {
+    const body = source.slice(
+      source.indexOf("async function resolveShortcut("),
+      source.indexOf("type AddDiscoveredFile ="),
+    );
+
+    // `shortcutDetails.targetId` is optional in the schema — a shortcut whose
+    // target was deleted is a real Drive state — so this branch is reachable
+    // on a well-formed page. A bare `Error` here falls through every
+    // classification branch: `add()` rethrows it and aborts the whole
+    // selection snapshot, and `recordDriveChangeFailure` rethrows it before
+    // reconcileChangePages persists the page cursor. That is the poison-page
+    // failure this Lambda exists to prevent, relocated from Zod validation to
+    // shortcut resolution.
+    expect(body).toContain("new GoogleDriveUnreadableFileError(");
+    expect(body).not.toContain("throw new Error(");
+  });
+
   test("a removed drive selection is retired scoped, not connector-wide", () => {
     const body = source.slice(
       source.indexOf("async function enumerateInitialFiles("),

--- a/tests/unit/google-content-sync-change-scope.test.ts
+++ b/tests/unit/google-content-sync-change-scope.test.ts
@@ -164,4 +164,35 @@ describe("processGoogleDriveChange guard wiring", () => {
     expect(loop).toContain("runSelectionSnapshot:");
     expect(loop).toContain("markSnapshotPending:");
   });
+
+  test("an unreadable file record fails the one change, never the page", () => {
+    const body = source.slice(
+      source.indexOf("async function recordDriveChangeFailure("),
+      source.indexOf("async function processGoogleDriveChange("),
+    );
+    const unreadable = body.indexOf("GoogleDriveUnreadableFileError");
+    const rethrow = body.indexOf(
+      "if (!isGoogleDriveMissingError(error)) throw error;",
+    );
+
+    // The unreadable branch must be classified before the catch-all rethrow —
+    // a ZodError from getFile that escapes this function replays the page
+    // until the DLQ, the poison pattern this Lambda exists to avoid — and it
+    // must fail the record, never reinterpret it as a removal.
+    expect(unreadable).toBeGreaterThan(-1);
+    expect(rethrow).toBeGreaterThan(-1);
+    expect(unreadable).toBeLessThan(rethrow);
+    expect(body).toContain("recordSourceFailure(context, fileId, error)");
+  });
+
+  test("an incomplete initial rebuild leaves a durable snapshot obligation", () => {
+    const body = source.slice(
+      source.indexOf("async function reconcileInitial("),
+      source.indexOf("async function retryDeferredDownloads("),
+    );
+    // Without this, files hidden behind a dropped entry during the very first
+    // enumeration (or a 410 rebuild) are only recovered if they happen to
+    // change again — the changes-loop path already retries its obligation.
+    expect(body).toContain("setSelectionSnapshotPending(context, !complete)");
+  });
 });

--- a/tests/unit/google-content-sync-change-scope.test.ts
+++ b/tests/unit/google-content-sync-change-scope.test.ts
@@ -185,6 +185,24 @@ describe("processGoogleDriveChange guard wiring", () => {
     expect(body).toContain("recordSourceFailure(context, fileId, error)");
   });
 
+  test("a removed drive selection is retired scoped, not connector-wide", () => {
+    const body = source.slice(
+      source.indexOf("async function enumerateInitialFiles("),
+      source.indexOf("async function selectedViaForFile("),
+    );
+    const missingBranch = body.indexOf("isGoogleDriveMissingError(error)");
+
+    expect(missingBranch).toBeGreaterThan(-1);
+    expect(body).toContain("inaccessibleSelectionCount += 1");
+    // The branch must NOT be gated on selectionKind. Rethrowing for `drive`
+    // selections escalated one removed Shared Drive into
+    // markConnectorAccessLost, which marks every source on the connector —
+    // including still-readable file and folder selections — and the deletion
+    // grace period then removes their content. Continuing lets
+    // markUnseenSourcesMissing retire only what this enumeration did not see.
+    expect(body).not.toContain('selection.selectionKind !== "drive"');
+  });
+
   test("an incomplete initial rebuild leaves a durable snapshot obligation", () => {
     const body = source.slice(
       source.indexOf("async function reconcileInitial("),

--- a/tests/unit/google-content-sync-reconcile.test.ts
+++ b/tests/unit/google-content-sync-reconcile.test.ts
@@ -1,0 +1,242 @@
+/** @jest-environment node */
+
+import {
+  isSelectionSnapshotPending,
+  reconcileChangePages,
+  resumePendingSelectionSnapshot,
+  SELECTION_SNAPSHOT_PENDING_KEY,
+  shouldRetireUnseenSources,
+  type ChangesPage,
+  type ReconcileChangesDeps,
+} from "../../infra/lambdas/google-content-sync/reconcile";
+
+interface Recorder {
+  events: string[];
+  cursors: string[];
+  deps: ReconcileChangesDeps<string>;
+}
+
+function page(
+  values: string[],
+  nextPageToken: string | null,
+  newStartPageToken: string | null = null,
+): ChangesPage<string> {
+  return { values, nextPageToken, newStartPageToken };
+}
+
+function recorder(options: {
+  pages: Array<ChangesPage<string>>;
+  demandsSnapshot?: (change: string) => boolean;
+  snapshotComplete?: boolean;
+  snapshotThrows?: boolean;
+}): Recorder {
+  const events: string[] = [];
+  const cursors: string[] = [];
+  let pageIndex = 0;
+  return {
+    events,
+    cursors,
+    deps: {
+      listChanges: async (cursor) => {
+        events.push(`list:${cursor}`);
+        const next = options.pages[pageIndex];
+        pageIndex += 1;
+        if (!next) throw new Error("listChanges called more times than staged");
+        return next;
+      },
+      processChange: async (change) => {
+        events.push(`process:${change}`);
+        return options.demandsSnapshot?.(change) ?? false;
+      },
+      persistCursor: async (cursor) => {
+        events.push(`persist:${cursor}`);
+        cursors.push(cursor);
+      },
+      markSnapshotPending: async () => {
+        events.push("mark-pending");
+      },
+      runSelectionSnapshot: async () => {
+        events.push("snapshot");
+        if (options.snapshotThrows) throw new Error("snapshot failed");
+        return options.snapshotComplete ?? true;
+      },
+      clearSnapshotPending: async () => {
+        events.push("clear-pending");
+      },
+    },
+  };
+}
+
+describe("selection snapshot obligation flag", () => {
+  test("is detected only when the connector metadata carries a timestamp", () => {
+    expect(isSelectionSnapshotPending(undefined)).toBe(false);
+    expect(isSelectionSnapshotPending(null)).toBe(false);
+    expect(isSelectionSnapshotPending({})).toBe(false);
+    expect(
+      isSelectionSnapshotPending({
+        [SELECTION_SNAPSHOT_PENDING_KEY]: "2026-08-07T00:00:00.000Z",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("reconcileChangePages cursor durability", () => {
+  test("advances the cursor after every page", async () => {
+    const { deps, cursors } = recorder({
+      pages: [page(["a"], "cursor-2"), page(["b"], null, "start-3")],
+    });
+
+    const cursor = await reconcileChangePages("cursor-1", deps);
+
+    expect(cursors).toEqual(["cursor-2", "start-3"]);
+    expect(cursor).toBe("start-3");
+  });
+
+  test("keeps advancing the cursor while a snapshot obligation is outstanding", async () => {
+    // This is the regression: the old loop suppressed every per-page cursor
+    // write once a page demanded a snapshot, so a Lambda timeout replayed all
+    // of the already-processed change pages on the next attempt.
+    const { deps, cursors, events } = recorder({
+      pages: [page(["removal"], "cursor-2"), page(["b"], null, "start-3")],
+      demandsSnapshot: (change) => change === "removal",
+    });
+
+    await reconcileChangePages("cursor-1", deps);
+
+    expect(cursors).toEqual(["cursor-2", "start-3"]);
+    // The obligation is durable BEFORE the cursor moves past the page that
+    // raised it — a crash in between can only replay work, never lose it.
+    expect(events.indexOf("mark-pending")).toBeLessThan(
+      events.indexOf("persist:cursor-2"),
+    );
+  });
+
+  test("records the obligation once, no matter how many entries demand it", async () => {
+    const { deps, events } = recorder({
+      pages: [page(["r1", "r2", "r3"], null, "start-2")],
+      demandsSnapshot: () => true,
+    });
+
+    await reconcileChangePages("cursor-1", deps);
+
+    expect(events.filter((event) => event === "mark-pending")).toHaveLength(1);
+  });
+
+  test("runs the snapshot after the feed is drained and clears the flag", async () => {
+    const { deps, events } = recorder({
+      pages: [page(["removal"], "cursor-2"), page([], null, "start-3")],
+      demandsSnapshot: () => true,
+    });
+
+    await reconcileChangePages("cursor-1", deps);
+
+    expect(events).toEqual([
+      "list:cursor-1",
+      "process:removal",
+      "mark-pending",
+      "persist:cursor-2",
+      "list:cursor-2",
+      "persist:start-3",
+      "snapshot",
+      "clear-pending",
+    ]);
+  });
+
+  test("leaves the flag set when the snapshot enumeration was incomplete", async () => {
+    // An incomplete enumeration never feeds the unseen-source sweep, so the
+    // obligation is not discharged and the next run retries it.
+    const { deps, events } = recorder({
+      pages: [page(["removal"], null, "start-2")],
+      demandsSnapshot: () => true,
+      snapshotComplete: false,
+    });
+
+    await reconcileChangePages("cursor-1", deps);
+
+    expect(events).toContain("snapshot");
+    expect(events).not.toContain("clear-pending");
+  });
+
+  test("leaves the flag set when the snapshot throws, after the cursor advanced", async () => {
+    const { deps, cursors, events } = recorder({
+      pages: [page(["removal"], null, "start-2")],
+      demandsSnapshot: () => true,
+      snapshotThrows: true,
+    });
+
+    await expect(reconcileChangePages("cursor-1", deps)).rejects.toThrow(
+      "snapshot failed",
+    );
+
+    // The change-page work is banked; only the snapshot is retried.
+    expect(cursors).toEqual(["start-2"]);
+    expect(events).not.toContain("clear-pending");
+  });
+
+  test("never marks the obligation when no entry demands a snapshot", async () => {
+    const { deps, events } = recorder({
+      pages: [page(["a", "b"], null, "start-2")],
+    });
+
+    await reconcileChangePages("cursor-1", deps);
+
+    expect(events).not.toContain("mark-pending");
+    expect(events).not.toContain("snapshot");
+  });
+
+  test("holds the cursor when Google returns neither token", async () => {
+    const { deps, cursors } = recorder({ pages: [page(["a"], null, null)] });
+
+    const cursor = await reconcileChangePages("cursor-1", deps);
+
+    expect(cursor).toBe("cursor-1");
+    expect(cursors).toEqual(["cursor-1"]);
+  });
+});
+
+describe("resumePendingSelectionSnapshot", () => {
+  test("discharges the obligation only after a complete snapshot", async () => {
+    const events: string[] = [];
+    const complete = await resumePendingSelectionSnapshot({
+      runSelectionSnapshot: async () => {
+        events.push("snapshot");
+        return true;
+      },
+      clearSnapshotPending: async () => {
+        events.push("clear-pending");
+      },
+    });
+
+    expect(complete).toBe(true);
+    expect(events).toEqual(["snapshot", "clear-pending"]);
+  });
+
+  test("keeps the obligation when the snapshot was incomplete", async () => {
+    const events: string[] = [];
+    const complete = await resumePendingSelectionSnapshot({
+      runSelectionSnapshot: async () => {
+        events.push("snapshot");
+        return false;
+      },
+      clearSnapshotPending: async () => {
+        events.push("clear-pending");
+      },
+    });
+
+    expect(complete).toBe(false);
+    expect(events).toEqual(["snapshot"]);
+  });
+});
+
+describe("shouldRetireUnseenSources", () => {
+  test("allows the sweep only after a complete enumeration", () => {
+    expect(shouldRetireUnseenSources({ skippedEntryCount: 0 })).toBe(true);
+  });
+
+  test("blocks the sweep when any entry was dropped by validation", () => {
+    // Marking a still-existing file missing because one record was
+    // unreadable would be silent data loss.
+    expect(shouldRetireUnseenSources({ skippedEntryCount: 1 })).toBe(false);
+    expect(shouldRetireUnseenSources({ skippedEntryCount: 250 })).toBe(false);
+  });
+});

--- a/tests/unit/lib/repositories/google-drive-changes-feed.test.ts
+++ b/tests/unit/lib/repositories/google-drive-changes-feed.test.ts
@@ -202,6 +202,20 @@ describe("GoogleDriveClient file entry tolerance", () => {
     expect(page.values[0]?.modifiedTime).toBe("2026-08-06T12:00:00Z");
   });
 
+  test("drops an unparseable timestamp instead of importing an Invalid Date", async () => {
+    // Accepting the entry is right — rejecting it would be the poison-page
+    // class. Carrying the raw string through is not: `sourceIdentityFields`
+    // feeds modifiedTime to `new Date(...)` and a timestamp column, so an
+    // Invalid Date fails the import transaction. And because the entry
+    // validated, it is not counted as a skipped entry, so the cursor advances
+    // and the unseen-source sweep is not suppressed — the file would stay
+    // unimported indefinitely rather than being retried.
+    const page = await listOneFile({ modifiedTime: "not-a-timestamp" });
+    expect(page.skippedEntries).toEqual([]);
+    expect(page.values[0]?.id).toBe("file-1");
+    expect(page.values[0]?.modifiedTime).toBeUndefined();
+  });
+
   test("accepts a non-numeric size instead of rejecting the entry", async () => {
     // The streaming byte bound is authoritative, so a surprising size string
     // must not cost us the file.

--- a/tests/unit/lib/repositories/google-drive-changes-feed.test.ts
+++ b/tests/unit/lib/repositories/google-drive-changes-feed.test.ts
@@ -1,0 +1,89 @@
+/** @jest-environment node */
+
+import { GoogleDriveClient } from "@/lib/repositories/google-drive/drive-client";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers({ "content-type": "application/json" }),
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("GoogleDriveClient changes feed", () => {
+  test("accepts Shared Drive-scoped change entries that carry no fileId", async () => {
+    // Regression: Google emits changeType "drive" entries (Shared Drive
+    // rename/membership/restriction events) with no fileId. Requiring fileId
+    // made listChanges throw before the cursor advanced, so the sync Lambda
+    // retried the same page forever and the queue filled with poison messages.
+    const fetchMock = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockResolvedValue(
+        jsonResponse({
+          newStartPageToken: "start-2",
+          changes: [
+            {
+              changeType: "drive",
+              time: "2026-08-06T12:00:00.000Z",
+              driveId: "drive-1",
+            },
+            {
+              changeType: "file",
+              fileId: "file-1",
+              time: "2026-08-06T12:00:01.000Z",
+            },
+          ],
+        }),
+      );
+
+    const page = await new GoogleDriveClient("token", {
+      fetch: fetchMock,
+    }).listChanges("cursor-1", "drive-1");
+
+    expect(page.values).toHaveLength(2);
+    expect(page.values[0]).toEqual(
+      expect.objectContaining({ changeType: "drive", driveId: "drive-1" }),
+    );
+    expect(page.values[0]?.fileId).toBeUndefined();
+    expect(page.values[1]).toEqual(
+      expect.objectContaining({ changeType: "file", fileId: "file-1" }),
+    );
+    expect(page.newStartPageToken).toBe("start-2");
+  });
+
+  test("tolerates change types Google has not shipped yet", async () => {
+    const fetchMock = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockResolvedValue(
+        jsonResponse({
+          newStartPageToken: "start-3",
+          changes: [{ changeType: "someFutureScope" }],
+        }),
+      );
+
+    const page = await new GoogleDriveClient("token", {
+      fetch: fetchMock,
+    }).listChanges("cursor-1");
+
+    expect(page.values).toEqual([
+      expect.objectContaining({ changeType: "someFutureScope" }),
+    ]);
+  });
+
+  test("requests changeType in the changes fields projection", async () => {
+    const fetchMock = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockResolvedValue(jsonResponse({ newStartPageToken: "start-1" }));
+
+    await new GoogleDriveClient("token", { fetch: fetchMock }).listChanges(
+      "cursor-1",
+    );
+
+    const fields = new URL(
+      String(fetchMock.mock.calls[0]?.[0]),
+    ).searchParams.get("fields");
+    expect(fields).toContain("changes(changeType,fileId,");
+  });
+
+});

--- a/tests/unit/lib/repositories/google-drive-changes-feed.test.ts
+++ b/tests/unit/lib/repositories/google-drive-changes-feed.test.ts
@@ -264,7 +264,8 @@ describe("GoogleDriveClient file entry tolerance", () => {
 
   test("accepts a shortcut that omits targetMimeType", async () => {
     // targetMimeType has no reader; only targetId is dereferenced, and its
-    // absence already has a graceful "no target" path.
+    // absence raises a typed GoogleDriveUnreadableFileError that both
+    // resolveShortcut call sites classify as a per-entry skip.
     const page = await listOneFile({
       mimeType: "application/vnd.google-apps.shortcut",
       shortcutDetails: { targetId: "target-1" },

--- a/tests/unit/lib/repositories/google-drive-changes-feed.test.ts
+++ b/tests/unit/lib/repositories/google-drive-changes-feed.test.ts
@@ -1,6 +1,9 @@
 /** @jest-environment node */
 
-import { GoogleDriveClient } from "@/lib/repositories/google-drive/drive-client";
+import {
+  GoogleDriveClient,
+  GoogleDriveUnreadableFileError,
+} from "@/lib/repositories/google-drive/drive-client";
 
 function jsonResponse(body: unknown, status = 200): Response {
   return {
@@ -308,5 +311,43 @@ describe("GoogleDriveClient file entry tolerance", () => {
     expect(page.skippedEntries).toEqual([
       expect.objectContaining({ index: 0, id: null }),
     ]);
+  });
+});
+
+describe("GoogleDriveClient getFile", () => {
+  test("throws the typed unreadable-file error, not a raw ZodError", async () => {
+    // getFile backs shortcut resolution and the parent-selection walk during
+    // change processing. A ZodError escaping here is unclassifiable to the
+    // caller and would fail the whole run — replaying the page until the DLQ,
+    // the same poison pattern the per-entry list parsing eliminates.
+    const fetchMock = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockResolvedValue(
+        jsonResponse({ id: "file-1", name: 42, mimeType: "application/pdf" }),
+      );
+
+    const pending = new GoogleDriveClient("token", {
+      fetch: fetchMock,
+    }).getFile("file-1");
+
+    await expect(pending).rejects.toBeInstanceOf(
+      GoogleDriveUnreadableFileError,
+    );
+    await expect(pending).rejects.toMatchObject({
+      fileId: "file-1",
+      issues: [expect.objectContaining({ path: "name" })],
+    });
+  });
+
+  test("returns a healthy file record", async () => {
+    const fetchMock = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockResolvedValue(jsonResponse(fileEntry("file-1")));
+
+    const file = await new GoogleDriveClient("token", {
+      fetch: fetchMock,
+    }).getFile("file-1");
+
+    expect(file.id).toBe("file-1");
   });
 });

--- a/tests/unit/lib/repositories/google-drive-changes-feed.test.ts
+++ b/tests/unit/lib/repositories/google-drive-changes-feed.test.ts
@@ -11,6 +11,15 @@ function jsonResponse(body: unknown, status = 200): Response {
   } as unknown as Response;
 }
 
+function fileEntry(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    name: `File ${id}`,
+    mimeType: "application/vnd.google-apps.document",
+    ...overrides,
+  };
+}
+
 describe("GoogleDriveClient changes feed", () => {
   test("accepts Shared Drive-scoped change entries that carry no fileId", async () => {
     // Regression: Google emits changeType "drive" entries (Shared Drive
@@ -71,6 +80,87 @@ describe("GoogleDriveClient changes feed", () => {
     ]);
   });
 
+  test("keeps every well-formed entry when one entry is malformed", async () => {
+    // Regression class: one poisoned entry among a thousand used to reject the
+    // whole page, so the cursor never advanced and the connector stalled —
+    // exactly the original fileId incident with a different field.
+    const fetchMock = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockResolvedValue(
+        jsonResponse({
+          nextPageToken: "page-2",
+          changes: [
+            { changeType: "file", fileId: "file-1", file: fileEntry("file-1") },
+            // `file.name` is a number: not representable, so this entry alone
+            // is dropped.
+            {
+              changeType: "file",
+              fileId: "file-2",
+              file: { ...fileEntry("file-2"), name: 42 },
+            },
+            { changeType: "file", fileId: "file-3", file: fileEntry("file-3") },
+          ],
+        }),
+      );
+
+    const page = await new GoogleDriveClient("token", {
+      fetch: fetchMock,
+    }).listChanges("cursor-1");
+
+    expect(page.values.map((change) => change.fileId)).toEqual([
+      "file-1",
+      "file-3",
+    ]);
+    // The page still yields its continuation token, so the cursor advances.
+    expect(page.nextPageToken).toBe("page-2");
+    expect(page.skippedEntries).toHaveLength(1);
+    expect(page.skippedEntries[0]).toEqual(
+      expect.objectContaining({ index: 1, id: "file-2" }),
+    );
+    expect(page.skippedEntries[0]?.issues[0]?.path).toBe("file.name");
+    expect(page.skippedEntries[0]?.issues[0]?.message).toEqual(
+      expect.any(String),
+    );
+  });
+
+  test("extracts an identifier from a malformed entry when one is present", async () => {
+    const fetchMock = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockResolvedValue(
+        jsonResponse({
+          newStartPageToken: "start-9",
+          changes: [{ fileId: 12, file: { id: "nested-1" } }, "not-an-object"],
+        }),
+      );
+
+    const page = await new GoogleDriveClient("token", {
+      fetch: fetchMock,
+    }).listChanges("cursor-1");
+
+    expect(page.values).toHaveLength(0);
+    expect(page.skippedEntries.map((entry) => entry.id)).toEqual([
+      "nested-1",
+      null,
+    ]);
+  });
+
+  test("reports no skipped entries for a healthy page", async () => {
+    const fetchMock = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockResolvedValue(
+        jsonResponse({
+          newStartPageToken: "start-4",
+          changes: [{ changeType: "file", fileId: "file-1" }],
+        }),
+      );
+
+    const page = await new GoogleDriveClient("token", {
+      fetch: fetchMock,
+    }).listChanges("cursor-1");
+
+    expect(page.skippedEntries).toEqual([]);
+  });
+
   test("requests changeType in the changes fields projection", async () => {
     const fetchMock = jest
       .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
@@ -86,4 +176,137 @@ describe("GoogleDriveClient changes feed", () => {
     expect(fields).toContain("changes(changeType,fileId,");
   });
 
+});
+
+describe("GoogleDriveClient file entry tolerance", () => {
+  async function listOneFile(overrides: Record<string, unknown>) {
+    const fetchMock = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockResolvedValue(
+        jsonResponse({ files: [fileEntry("file-1", overrides)] }),
+      );
+    const page = await new GoogleDriveClient("token", {
+      fetch: fetchMock,
+    }).listChildren("folder-1");
+    return page;
+  }
+
+  test("accepts timestamps Google formats without a UTC offset", async () => {
+    // The only consumers are `new Date(...)` and a revision string; a strict
+    // RFC-3339-with-offset validator would have rejected the whole page.
+    const page = await listOneFile({ modifiedTime: "2026-08-06T12:00:00Z" });
+    expect(page.skippedEntries).toEqual([]);
+    expect(page.values[0]?.modifiedTime).toBe("2026-08-06T12:00:00Z");
+  });
+
+  test("accepts a non-numeric size instead of rejecting the entry", async () => {
+    // The streaming byte bound is authoritative, so a surprising size string
+    // must not cost us the file.
+    const page = await listOneFile({ size: "unknown" });
+    expect(page.skippedEntries).toEqual([]);
+    expect(page.values[0]?.size).toBe("unknown");
+  });
+
+  test("keeps http(s) links and drops non-navigable schemes", async () => {
+    const kept = await listOneFile({
+      webViewLink: "https://drive.example.test/d/file-1",
+      iconLink: "http://drive.example.test/icon.png",
+    });
+    expect(kept.values[0]?.webViewLink).toBe(
+      "https://drive.example.test/d/file-1",
+    );
+    expect(kept.values[0]?.iconLink).toBe("http://drive.example.test/icon.png");
+
+    // Loosening the URL validator must not make the field an injection
+    // vector: a non-http(s) scheme is dropped, not persisted.
+    const dropped = await listOneFile({
+      webViewLink: "javascript:alert(1)",
+      iconLink: "data:text/html,<script>",
+    });
+    expect(dropped.skippedEntries).toEqual([]);
+    expect(dropped.values[0]?.webViewLink).toBeUndefined();
+    expect(dropped.values[0]?.iconLink).toBeUndefined();
+  });
+
+  test("accepts explicit nulls where Google could send them", async () => {
+    const page = await listOneFile({
+      parents: null,
+      driveId: null,
+      owners: null,
+      trashed: null,
+      modifiedTime: null,
+      md5Checksum: null,
+      shortcutDetails: null,
+    });
+    expect(page.skippedEntries).toEqual([]);
+    expect(page.values[0]?.parents).toEqual([]);
+    expect(page.values[0]?.owners).toEqual([]);
+    expect(page.values[0]?.trashed).toBe(false);
+    expect(page.values[0]?.driveId).toBeUndefined();
+  });
+
+  test("accepts a shortcut that omits targetMimeType", async () => {
+    // targetMimeType has no reader; only targetId is dereferenced, and its
+    // absence already has a graceful "no target" path.
+    const page = await listOneFile({
+      mimeType: "application/vnd.google-apps.shortcut",
+      shortcutDetails: { targetId: "target-1" },
+    });
+    expect(page.skippedEntries).toEqual([]);
+    expect(page.values[0]?.shortcutDetails?.targetId).toBe("target-1");
+    expect(page.values[0]?.shortcutDetails?.targetMimeType).toBeUndefined();
+  });
+
+  test("accepts a shortcut that omits targetId, leaving the graceful path", async () => {
+    const page = await listOneFile({
+      mimeType: "application/vnd.google-apps.shortcut",
+      shortcutDetails: { targetMimeType: "application/pdf" },
+    });
+    expect(page.skippedEntries).toEqual([]);
+    expect(page.values[0]?.shortcutDetails?.targetId).toBeUndefined();
+  });
+
+  test("skips only the malformed child and still paginates", async () => {
+    const fetchMock = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockResolvedValue(
+        jsonResponse({
+          nextPageToken: "page-2",
+          files: [
+            fileEntry("file-1"),
+            { ...fileEntry("file-2"), mimeType: null },
+            fileEntry("file-3"),
+          ],
+        }),
+      );
+
+    const page = await new GoogleDriveClient("token", {
+      fetch: fetchMock,
+    }).listChildren("folder-1");
+
+    expect(page.values.map((file) => file.id)).toEqual(["file-1", "file-3"]);
+    expect(page.nextPageToken).toBe("page-2");
+    expect(page.skippedEntries).toEqual([
+      expect.objectContaining({ index: 1, id: "file-2" }),
+    ]);
+  });
+
+  test("skips only the malformed entry when enumerating a Shared Drive", async () => {
+    const fetchMock = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockResolvedValue(
+        jsonResponse({
+          files: [{ name: "no id" }, fileEntry("file-9")],
+        }),
+      );
+
+    const page = await new GoogleDriveClient("token", {
+      fetch: fetchMock,
+    }).listSharedDriveFiles("drive-1");
+
+    expect(page.values.map((file) => file.id)).toEqual(["file-9"]);
+    expect(page.skippedEntries).toEqual([
+      expect.objectContaining({ index: 0, id: null }),
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

Hardens the Google Drive content-sync pipeline against the whole *class* of poison-page failures that caused the 2026-08-06 prod incident, closes the durable-obligation gap around selection snapshots, and puts the lambda under the TypeScript compiler for the first time.

> **Stacks on #1617.** This branch is cut from `claude/google-sync-queue-backlog-b836ae`; until #1617 merges, its two commits appear in this diff. Merge #1617 first, then this.

Follow-up scope approved by @hagelk after #1617 deliberately shipped root-cause-only.

## Gap 1 — all-or-nothing page parsing (`lib/repositories/google-drive/drive-client.ts`)

`changesListSchema`/`filesListSchema` used to `z.array(entrySchema).parse()` the whole payload: one malformed entry among 1000 rejected the page, the cursor never advanced, and the connector stalled — the original `fileId` incident, generalized.

- **Per-entry validation**: list envelopes now parse entries as `unknown[]`, then validate one at a time (`parseDriveEntries`). A malformed member costs that one entry, not the page. Skipped entries surface as `skippedEntries` (index, best-effort id, zod issues) and are logged loudly at every call site. **A parse failure is never reinterpreted as a removal** — dropped entries suppress the unseen-source sweep instead (see Gap 2).
- **Validators loosened to Google's actual contract**, each with a comment tying it to its consumer: `modifiedTime`/`time` plain strings (consumers do `new Date(...)`); `size` plain string (the streaming byte bound is authoritative); `shortcutDetails.targetId`/`targetMimeType` optional (`resolveShortcut` already has the graceful "no target" path; `targetMimeType` has no reader); `.nullish()` + normalizing transforms where Google could send explicit `null`.
- **`webViewLink`/`iconLink`**: strict `.url()` dropped, but a non-http(s) scheme (`javascript:`, `data:`) is discarded rather than persisted, so the loosening cannot open an href-injection path.
- **`getFile()` (single-entity sibling of the same gap)**: now `safeParse`s and throws a typed `GoogleDriveUnreadableFileError` (fileId + issues) instead of a raw `ZodError`. Callers classify it explicitly: a change-processing failure fails that one record (`recordSourceFailure`, never `markSourceMissing`, cursor advances); an unreadable shortcut target or selection root during enumeration counts as a skipped entry. Found by adversarial review of the first commit — a ZodError escaping `getFile` mid-change-page would have replayed the page until the DLQ, the exact pattern this PR eliminates.

## Gap 2 — snapshot obligation now durable (`infra/lambdas/google-content-sync/`)

Previously, a change page that demanded a selection snapshot suppressed every per-page cursor write until the snapshot finished. A 900s Lambda timeout or budget failure threw away all change-page work and replayed it from the original cursor — indefinitely, if the snapshot kept failing.

- New `reconcile.ts` extracts the changes-feed loop against injected collaborators (same pattern as `changes.ts`/`safety.ts`; `index.ts` cannot be imported from the root jest gate). Ordering invariants, each behaviorally tested:
  1. The obligation is written durably (`metadata.selectionSnapshotPendingAt`, jsonb merge — **no migration needed**) *before* the cursor moves past the page that raised it.
  2. The cursor persists after every page, unconditionally.
  3. The flag clears only after a *complete* snapshot; an incomplete one (dropped entries) retains it, so the next run retries.
- On sync start, a pending obligation is discharged *before* consuming new pages (`resolveSyncCursor`).
- `shouldRetireUnseenSources`: `markUnseenSourcesMissing` only runs after a complete enumeration — a dropped entry says nothing about its file's existence, so retiring on partial data would be silent data loss.
- `reconcileInitial` records the obligation on an incomplete initial/410-rebuild too (`setSelectionSnapshotPending(context, !complete)`), aligning it with the changes-loop path (correctness-review finding).

## Gap 3 — lambda now type-checked

`infra/lambdas/google-content-sync/` had no tsconfig and was excluded from both the root and infra `tsc` runs — esbuild only transpiles. Added `tsconfig.json` (modeled on `unified-content-processor`) and `typecheck:google-content-sync`, wired into `infra`'s `build` script exactly like the sibling check. The duplicate local re-derivation of `GoogleDriveChange` in `index.ts` is replaced by the exported type.

## Deliberately unchanged

- No DLQ redrive, no alarm-threshold changes (locked decisions from #1617).
- `enumerateInitialFiles`'s 403/404-on-selection-root behavior (retire via the missing path) is pre-existing and intentional parity with file-level 403/404 semantics — not widened here.

## Verification

- `bun run lint` — zero warnings
- `bun run typecheck` + `typecheck:google-content-sync` — clean
- Full jest suite: 574 suites / 5465 passed (one unrelated `document-generation-service` xlsx test hit its 5s timeout under machine load; passes in isolation in 1.1s)
- Full local Playwright gate: 306 passed / 40 skipped; one `nexus/model-router` failure + 10 flaky-passed-on-retry, all Nexus/Atrium UI specs untouched by this backend diff. The failed spec was rerun in isolation and passed (10 passed / 1 flaky-passed-on-retry / 0 failed) — load-induced flake from two sessions' gates sharing the machine, not a regression
- New coverage: 16 drive-client contract tests (per-entry skip, null tolerance, scheme filtering, shortcut edge cases, typed `getFile` error), 12 reconcile-loop behavior tests (cursor/obligation ordering, incomplete-snapshot retention), change-scope wiring assertions

**Named E2E flows**: none — backend Lambda path, not reachable via Playwright; covered by unit/contract tests above.
